### PR TITLE
Added support for at-rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,9 @@ module.exports = function plugin(options) {
       }
     }, rule.source)
   }
-  
+
   return function(style) {
-    style.eachInside(function (rule) {
+    style.eachInside(function(rule) {
       switch (rule.type) {
         case "decl":
           transformRule(rule, "value")


### PR DESCRIPTION
This change enables the use of ```calc``` in at-rules, which would come in handy in conjunction with plugins such as [postcss-for] and [postcss-conditionals].

[postcss-for]: https://github.com/antyakushev/postcss-for
[postcss-conditionals]: https://github.com/andyjansson/postcss-conditionals 

E.g.:

```css
p {
  @if calc(1 + 1) == 2 { border: 1px solid;  }
}
``` 