### PR TITLE
Use PostCSS 4.1 API

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,12 @@
  */
 var reduceCSSCalc = require("reduce-css-calc")
 var helpers = require("postcss-message-helpers")
+var postcss = require("postcss");
 
 /**
  * PostCSS plugin to reduce calc() function calls.
  */
-module.exports = function plugin(options) {
+module.exports = postcss.plugin("postcss-calc", function(options) {
   options = options || {}
   var precision = options.precision
   var preserve = options.preserve
@@ -34,4 +35,4 @@ module.exports = function plugin(options) {
       }, decl.source)
     })
   }
-}
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "css",
     "postcss",
-    "postcss-plugins",
+    "postcss-plugin",
     "calculation",
     "calc"
   ],
@@ -22,12 +22,12 @@
   ],
   "dependencies": {
     "postcss-message-helpers": "^2.0.0",
-    "reduce-css-calc": "^1.2.0"
+    "reduce-css-calc": "^1.2.0",
+    "postcss": "^4.1.11"
   },
   "devDependencies": {
     "jscs": "^1.6.2",
     "jshint": "^2.5.6",
-    "postcss": "^4.0.2",
     "postcss-custom-properties": "^3.0.0",
     "tape": "^3.0.0"
   },


### PR DESCRIPTION
Fix #11

`postcss.plugin()` is very important, because I got today two reports that `postcss-calc` doesn’t work, because developers just miss brackets.