### PR TITLE
Use PostCSS 5.0 API (version 2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = postcss.plugin("postcss-calc", function(options) {
   var preserve = options.preserve
 
   return function(style) {
-    style.eachDecl(function transformDecl(decl) {
+    style.walkDecls(function transformDecl(decl) {
       if (!decl.value || decl.value.indexOf("calc(") === -1) {
         return
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "postcss-message-helpers": "^2.0.0",
     "reduce-css-calc": "^1.2.0",
-    "postcss": "^4.1.11"
+    "postcss": "^5.0.2"
   },
   "devDependencies": {
     "jscs": "^1.6.2",


### PR DESCRIPTION
@MoOx this PR is important for me, because I can’t run PostCSS benchmark until `postcss-calc` prints warnings.