### PR TITLE
Add support for multiline value

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ body {
 h1 {
   font-size: calc(var(--main-font-size) * 2);
   height: calc(100px - 2em);
+  margin-bottom: calc(
+      var(--main-font-size)
+      * 1.5
+    )
 }
 ```
 
@@ -77,7 +81,8 @@ body {
 
 h1 {
   font-size: 32px;
-  height: calc(100px - 2em)
+  height: calc(100px - 2em);
+  margin-bottom: 24px
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var reduceCSSCalc = require("reduce-css-calc")
 var helpers = require("postcss-message-helpers")
 var postcss = require("postcss")
 
-var CONTAINS_CALC = /calc\(.*\)/
+var CONTAINS_CALC = /\bcalc\([\s\S]*?\)/
 
 /**
  * PostCSS plugin to reduce calc() function calls.

--- a/test/fixtures/multiline.css
+++ b/test/fixtures/multiline.css
@@ -1,0 +1,19 @@
+multiline {
+    font-size: calc(
+                       1rem
+                       * 2
+                       * 1.5
+                   );
+    width: calc(1px +
+      10px
+      + 100px );
+    height: calc(
+2em
+    + 20em + 200em);
+    padding: calc(30px
+      + 3px ) calc(
+2px *
+2
++40 px
+        );
+}

--- a/test/fixtures/multiline.expected.css
+++ b/test/fixtures/multiline.expected.css
@@ -1,0 +1,6 @@
+multiline {
+    font-size: 3rem;
+    width: 111px;
+    height: 222em;
+    padding: 33px 44px;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -72,6 +72,13 @@ test("calc", function(t) {
     "with media"
   )
 
+  compareFixtures(
+    t,
+    "multiline",
+    {},
+    "should resolve multiline calc value"
+  )
+
   var result = compareFixtures(
     t,
     "warnWhenCannotResolve",


### PR DESCRIPTION
## About

For those who like to write `calc()` on multilines or use a `max-line-length` rules in their CSS linter.

## Tests

I wrote some tests for this.
@MoOx can you have a look ? I'm not realy sure if I've done it right.

*multiline.css*
```css
multiline {
    font-size: calc(
                       1rem
                       * 2
                       * 1.5
                   );
    width: calc(1px +
      10px
      + 100px );
    height: calc(
2em
    + 20em + 200em);
    padding: calc(30px
      + 3px ) calc(
2px *
2
+40 px
        );
}
```

*multiline.expected.css*
```css
multiline {
    font-size: 3rem;
    width: 111px;
    height: 222em;
    padding: 33px 44px;
}
```

## Related issue(s)
- close #26 