### PR TITLE
Update reduce-css-calc dependency to ^1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "postcss-message-helpers": "^2.0.0",
-    "reduce-css-calc": "^1.2.0",
+    "reduce-css-calc": "^1.2.5",
     "postcss": "^5.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
We want `reduce-css-calc` dependency to upgrade to 1.2.5 or later asap, this ensures that on upgrading postcss-calc, reduce-css-calc would be also upgraded.