### PR TITLE
fix: do not break `calc` with single var

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -583,3 +583,24 @@ test(
   'calc(unknown(#fff) * other-unknown(200px))',
   'calc(unknown(#fff)*other-unknown(200px))',
 );
+
+test(
+  'should not strip calc with single CSS custom variable',
+  testValue,
+  'calc(var(--foo))',
+  'calc(var(--foo))',
+);
+
+test(
+  'should strip unnecessary calc with single CSS custom variable',
+  testValue,
+  'calc(calc(var(--foo)))',
+  'calc(var(--foo))',
+);
+
+test(
+  'should not strip calc with single CSS custom variables and value',
+  testValue,
+  'calc(var(--foo) + 10px)',
+  'calc(var(--foo) + 10px)',
+);

--- a/src/lib/stringifier.js
+++ b/src/lib/stringifier.js
@@ -52,7 +52,11 @@ export default function (
   ) {
   let str = stringify(node, options.precision);
 
-  if (node.type === "MathExpression") {
+  const shouldPrintCalc =
+    node.type === "MathExpression" ||
+    (node.type === "Function" && node.value.toLowerCase().slice(0, 4) === "var(");
+
+  if (shouldPrintCalc) {
     // if calc expression couldn't be resolved to a single value, re-wrap it as
     // a calc()
     str = `${calc}(${str})`;

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -12,8 +12,9 @@ const MATCH_CALC = /((?:-(moz|webkit)-)?calc)/i;
 function transformValue(value, options, result, item) {
   return valueParser(value).walk(node => {
     // skip anything which isn't a calc() function
-    if (node.type !== 'function' || !MATCH_CALC.test(node.value))
+    if (node.type !== 'function' || !MATCH_CALC.test(node.value)) {
       return node;
+    }
 
     // stringify calc expression and produce an AST
     const contents = valueParser.stringify(node.nodes);


### PR DESCRIPTION
Original issue https://github.com/cssnano/cssnano/issues/725