### PR TITLE
fix: incorrect reduction of subtraction from zero (#88)

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -119,6 +119,13 @@ test(
 );
 
 test(
+  'should reduce additions and subtractions (5)',
+  testValue,
+  'calc(10px - (100vw - 50em) / 2)',
+  'calc(10px - (100vw - 50em)/2)',
+);
+
+test(
   'should ignore value surrounding calc function (1)',
   testValue,
   'a calc(1px + 1px)',
@@ -361,10 +368,31 @@ test(
 );
 
 test(
-  'should reduce substracted division expression from zero',
+  'should reduce substracted expression from zero (1)',
   testValue,
   'calc( 0 - (100vw - 10px) / 2 )',
   'calc((-100vw - -10px)/2)',
+);
+
+test(
+  'should reduce substracted expression from zero (2)',
+  testValue,
+  'calc( 0px - (100vw - 10px))',
+  'calc(-100vw - -10px)',
+);
+
+test(
+  'should reduce substracted expression from zero (3)',
+  testValue,
+  'calc( 0px - (100vw - 10px) * 2px )',
+  'calc((-100vw - -10px)*2px)',
+);
+
+test(
+  'should reduce substracted expression from zero (4)',
+  testValue,
+  'calc( 0px - (100vw + 10px))',
+  'calc(-100vw + -10px)',
 );
 
 test(

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -361,6 +361,13 @@ test(
 );
 
 test(
+  'should reduce substracted division expression from zero',
+  testValue,
+  'calc( 0 - (100vw - 10px) / 2 )',
+  'calc((-100vw - -10px)/2)',
+);
+
+test(
   'should reduce nested expression',
   testValue,
   'calc( (1em - calc( 10px + 1em)) / 2)',

--- a/src/lib/reducer.js
+++ b/src/lib/reducer.js
@@ -34,8 +34,12 @@ function flipValue(node) {
   if (isValueType(node.type)) {
     node.value = -node.value;
   } else if (node.type === 'MathExpression') {
-    node.left = flipValue(node.left);
-    node.right = flipValue(node.right);
+    if (node.operator === '*' || node.operator === '/') {
+      node.left = flipValue(node.left);
+    } else {
+      node.left = flipValue(node.left);
+      node.right = flipValue(node.right);
+    }
   }
 
   return node;


### PR DESCRIPTION
This PR should fix #88, where a division expression subtracted from zero is incorrectly reduced. Apparently `reducer.js` does not reduce division expressions if the denominator cannot be reduced to a value, so similar multiplication tests pass while division did not.