### PR TITLE
Correctly handle summands that cancel out and pull out common factors

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -239,6 +239,13 @@ test(
   'calc(var(--popupHeight)/2)',
 );
 
+test(
+  'should ignore calc with css variables (7)',
+  testValue,
+  'calc(var(--popupHeight) / 2 + var(--popupWidth) / 2)',
+  'calc((var(--popupHeight) + var(--popupWidth))/2)',
+);
+
 
 test(
   'should reduce calc with newline characters',


### PR DESCRIPTION
Closes https://github.com/postcss/postcss-calc/issues/107

1. Only remove the `something` in `(expr + something) +- (expr - something)` if it's actually addition and subtraction that cancel out.
2. Pull out common factors in `(expr * something) +- (expr * something)` (for `var` expressions https://github.com/postcss/postcss-calc/issues/107#issuecomment-680747619 )