### PR TITLE
Insert more needed parenthesis

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -446,6 +446,13 @@ test(
 );
 
 test(
+  'should correctly preserve parentheses'
+  testValue,
+  'calc(1/((var(--a) - var(--b)) / 16))',
+  'calc(1/((var(--a) - var(--b)) / 16))'
+)
+
+test(
   'should preserve the original declaration when `preserve` option is set to true',
   testCss,
   'foo{bar:calc(1rem * 1.5)}',

--- a/src/lib/stringifier.js
+++ b/src/lib/stringifier.js
@@ -5,6 +5,30 @@ const order = {
   "-": 1,
 };
 
+var nonAssociative = {
+  '*': false,
+  '/': true,
+  '+': false,
+  '-': true
+}
+
+function needsParenthesis(op, childOp){
+  let opOrder = order[op];
+  let childOpOrder = order[childOp];
+  if (opOrder === childOpOrder){
+    // Chains of the same operation only need parenthesis if non-associative
+    if (op === childOp){
+      return nonAssociative[op];
+    } else {
+      // Same precedence but different operator: always
+      return true;
+    }
+  } else {
+    // Follow operator precendence
+    return order[op] < order[childOp];
+  }
+}
+
 function round(value, prec) {
   if (prec !== false) {
     const precision = Math.pow(10, prec);
@@ -19,7 +43,7 @@ function stringify(node, prec) {
       const {left, right, operator: op} = node;
       let str = "";
 
-      if (left.type === 'MathExpression' && order[op] < order[left.operator]) {
+      if (left.type === 'MathExpression' && needsParenthesis(op, left.operator)) {
         str += `(${stringify(left, prec)})`;
       } else {
         str += stringify(left, prec);
@@ -27,7 +51,7 @@ function stringify(node, prec) {
 
       str += order[op] ? ` ${node.operator} ` : node.operator;
 
-      if (right.type === 'MathExpression' && order[op] < order[right.operator]) {
+      if (right.type === 'MathExpression' && needsParenthesis(op, right.operator)) {
         str += `(${stringify(right, prec)})`;
       } else {
         str += stringify(right, prec);


### PR DESCRIPTION
Closes https://github.com/postcss/postcss-calc/issues/115

One thing that might be causing old tests to fail is that `calc` (and the postcss-calc parser) is probably left-associative by default, so no parentheses are needed in cases like `(a - b) - c`.