### PR TITLE
fix: improve types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,11 @@ import transform from './lib/transform';
  *          warnWhenCannotResolve?: boolean, 
  *          mediaQueries?: boolean, 
  *          selectors?: boolean}} PostCssCalcOptions
- *
+ */
+ /**
+ * @type {import('postcss').PluginCreator<PostCssCalcOptions>}
  * @param {PostCssCalcOptions} opts
+ * @return {import('postcss').Plugin}
  */
 function pluginCreator(opts) {
   const options = Object.assign({
@@ -20,10 +23,6 @@ function pluginCreator(opts) {
 
   return {
     postcssPlugin: 'postcss-calc',
-    /**
-     * @param {import('postcss').Root} css
-     * @param {{result: import('postcss').Result}} helpers
-     */ 
     OnceExit(css, { result }) {
       css.walk(node => {
         const { type } = node;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,19 +12,13 @@ export type PostCssCalcOptions = {
  *          warnWhenCannotResolve?: boolean,
  *          mediaQueries?: boolean,
  *          selectors?: boolean}} PostCssCalcOptions
- *
- * @param {PostCssCalcOptions} opts
  */
-declare function pluginCreator(opts: PostCssCalcOptions): {
-    postcssPlugin: string;
-    /**
-     * @param {import('postcss').Root} css
-     * @param {{result: import('postcss').Result}} helpers
-     */
-    OnceExit(css: import('postcss').Root, { result }: {
-        result: import('postcss').Result;
-    }): void;
-};
+/**
+* @type {import('postcss').PluginCreator<PostCssCalcOptions>}
+* @param {PostCssCalcOptions} opts
+* @return {import('postcss').Plugin}
+*/
+declare function pluginCreator(opts: PostCssCalcOptions): import('postcss').Plugin;
 declare namespace pluginCreator {
-    const postcss: boolean;
+    const postcss: true;
 }


### PR DESCRIPTION
Plugin creator needs postcss property set to `true`.
It's more intuitive to use the types if it explicitly returns a PostCSS plugin.