### PR TITLE
chore: update all deps except PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     }
   },
   "devDependencies": {
-    "@types/node": "^17.0.14",
-    "eslint": "^8.7.0",
+    "@types/node": "^17.0.15",
+    "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",
     "jison-gho": "^0.6.1-216",
     "postcss": "^8.2.2",
@@ -53,8 +53,8 @@
     "uvu": "^0.5.3"
   },
   "dependencies": {
-    "postcss-selector-parser": "^6.0.2",
-    "postcss-value-parser": "^4.0.2"
+    "postcss-selector-parser": "^6.0.9",
+    "postcss-value-parser": "^4.2.0"
   },
   "peerDependencies": {
     "postcss": "^8.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,25 +1,25 @@
 lockfileVersion: 5.3
 
 specifiers:
-  '@types/node': ^17.0.14
-  eslint: ^8.7.0
+  '@types/node': ^17.0.15
+  eslint: ^8.8.0
   eslint-config-prettier: ^8.3.0
   jison-gho: ^0.6.1-216
   postcss: ^8.2.2
-  postcss-selector-parser: ^6.0.2
-  postcss-value-parser: ^4.0.2
+  postcss-selector-parser: ^6.0.9
+  postcss-value-parser: ^4.2.0
   prettier: ^2.5.1
   typescript: ^4.5.5
   uvu: ^0.5.3
 
 dependencies:
-  postcss-selector-parser: 6.0.8
+  postcss-selector-parser: 6.0.9
   postcss-value-parser: 4.2.0
 
 devDependencies:
-  '@types/node': 17.0.14
-  eslint: 8.7.0
-  eslint-config-prettier: 8.3.0_eslint@8.7.0
+  '@types/node': 17.0.15
+  eslint: 8.8.0
+  eslint-config-prettier: 8.3.0_eslint@8.8.0
   jison-gho: 0.6.1-216
   postcss: 8.4.5
   prettier: 2.5.1
@@ -120,8 +120,8 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@types/node/17.0.14:
-    resolution: {integrity: sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==}
+  /@types/node/17.0.15:
+    resolution: {integrity: sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==}
     dev: true
 
   /acorn-jsx/5.3.2_acorn@8.7.0:
@@ -332,13 +332,13 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-prettier/8.3.0_eslint@8.7.0:
+  /eslint-config-prettier/8.3.0_eslint@8.8.0:
     resolution: {integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.8.0
     dev: true
 
   /eslint-scope/7.1.0:
@@ -349,13 +349,13 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-utils/3.0.0_eslint@8.7.0:
+  /eslint-utils/3.0.0_eslint@8.8.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.7.0
+      eslint: 8.8.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -369,8 +369,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint/8.7.0:
-    resolution: {integrity: sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==}
+  /eslint/8.8.0:
+    resolution: {integrity: sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
@@ -383,7 +383,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.0
-      eslint-utils: 3.0.0_eslint@8.7.0
+      eslint-utils: 3.0.0_eslint@8.8.0
       eslint-visitor-keys: 3.2.0
       espree: 9.3.0
       esquery: 1.4.0
@@ -823,8 +823,8 @@ packages:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
 
-  /postcss-selector-parser/6.0.8:
-    resolution: {integrity: sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==}
+  /postcss-selector-parser/6.0.9:
+    resolution: {integrity: sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0


### PR DESCRIPTION
I think there might be an issue with the latest PostCSS 4.6 which causes some comments not to be removed any more, so it's better to investigate that separately. Two tests fail with PostCSS 8.4.6