### PR TITLE
fix: remove comments before parsing calc value

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",
     "jison-gho": "^0.6.1-216",
-    "postcss": "^8.2.2",
+    "postcss": "^8.4.6",
     "prettier": "^2.5.1",
     "typescript": "^4.5.5",
     "uvu": "^0.5.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   eslint: ^8.8.0
   eslint-config-prettier: ^8.3.0
   jison-gho: ^0.6.1-216
-  postcss: ^8.2.2
+  postcss: ^8.4.6
   postcss-selector-parser: ^6.0.9
   postcss-value-parser: ^4.2.0
   prettier: ^2.5.1
@@ -21,7 +21,7 @@ devDependencies:
   eslint: 8.8.0
   eslint-config-prettier: 8.3.0_eslint@8.8.0
   jison-gho: 0.6.1-216
-  postcss: 8.4.5
+  postcss: 8.4.6
   prettier: 2.5.1
   typescript: 4.5.5
   uvu: 0.5.3
@@ -719,8 +719,8 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /nanoid/3.1.30:
-    resolution: {integrity: sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==}
+  /nanoid/3.2.0:
+    resolution: {integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -835,13 +835,13 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: false
 
-  /postcss/8.4.5:
-    resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
+  /postcss/8.4.6:
+    resolution: {integrity: sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.1.30
+      nanoid: 3.2.0
       picocolors: 1.0.0
-      source-map-js: 1.0.1
+      source-map-js: 1.0.2
     dev: true
 
   /prelude-ls/1.2.1:
@@ -939,8 +939,8 @@ packages:
     resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==}
     dev: true
 
-  /source-map-js/1.0.1:
-    resolution: {integrity: sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==}
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
     dev: true
 

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -8,6 +8,22 @@ const reducer = require('./reducer.js');
 const stringifier = require('./stringifier.js');
 
 const MATCH_CALC = /((?:-(moz|webkit)-)?calc)/i;
+/**
+ * @param {valueParser.Node[]} nodes
+ * @return {valueParser.Node[]}
+ */
+function removeComments(nodes) {
+  const newNodes = [];
+  for (const node of nodes) {
+    if (node.type !== 'comment') {
+      if (node.type === 'function') {
+        node.nodes = removeComments(node.nodes);
+      }
+      newNodes.push(node);
+    }
+  }
+  return newNodes;
+}
 
 /**
  * @param {string} value
@@ -23,8 +39,9 @@ function transformValue(value, options, result, item) {
         return;
       }
 
+      const noComments = removeComments(node.nodes);
       // stringify calc expression and produce an AST
-      const contents = valueParser.stringify(node.nodes);
+      const contents = valueParser.stringify(noComments);
       const ast = parser.parse(contents);
 
       // reduce AST to its simplest form, that is, either to a single value


### PR DESCRIPTION
Since 8.4.6, PostCSS stopped removing comments in declarations,
because it sometimes produced the wrong CSS.
postcss-calc can remove the comments safely because it only
modifies the contents of function nodes.