### PR TITLE
chore(release): 8.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [8.2.4](https://github.com/postcss/postcss-calc/compare/v8.2.3...v8.2.4) (2022-02-05)
+
+## Patch Changes
+
+* convert source to CommonJS and publish untranspiled code ([b55adcb](https://github.com/postcss/postcss-calc/commit/b55adcb285ea8d385bf802a0f7edeb2d12be1549))
+
 # [8.2.3](https://github.com/postcss/postcss-calc/compare/v8.2.2...v8.2.3) (2022-01-28)
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-calc",
-  "version": "8.2.3",
+  "version": "8.2.4",
   "description": "PostCSS plugin to reduce calc()",
   "keywords": [
     "css",


### PR DESCRIPTION
I think it's better to do one publish with the untranspiled source to check everything is OK with consumers, before we make any further changes. Especially concerning https://github.com/postcss/postcss-calc/pull/171, it might be better to not add comment processing to postcss-calc, since we already have that in postcss-discard-comments.