### PR TITLE
chore: move test directory ouf of src

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "prepare": "pnpm run build && tsc",
     "build": "jison src/parser.jison -o src/parser.js",
     "lint": "eslint . && tsc",
-    "pretest": "pnpm run build",
     "test": "uvu test"
   },
   "author": "Andy Jansson",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "prepare": "pnpm run build && tsc",
     "build": "jison src/parser.jison -o src/parser.js",
-    "lint": "eslint src && tsc",
+    "lint": "eslint . && tsc",
     "pretest": "pnpm run build",
-    "test": "uvu src/__tests__"
+    "test": "uvu test"
   },
   "author": "Andy Jansson",
   "license": "MIT",

--- a/test/convertUnit.js
+++ b/test/convertUnit.js
@@ -2,7 +2,7 @@
 const { test } = require('uvu');
 const assert = require('uvu/assert');
 
-const convertUnit = require('../lib/convertUnit.js');
+const convertUnit = require('../src/lib/convertUnit.js');
 
 test('valid conversions', () => {
   const conversions = [

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ const { test } = require('uvu');
 const assert = require('uvu/assert');
 const postcss = require('postcss');
 
-const reduceCalc = require('../index.js');
+const reduceCalc = require('../src/index.js');
 
 const postcssOpts = { from: undefined };
 


### PR DESCRIPTION
Bring the number of published files back to the previous level.
I considered using an .npmignore file but I think this solution
requires less npm knowledge to understand.

I've also renamed `__tests__` to `test` so the layout matches the
one in the postcss and webpack repositories.