### PR TITLE
fix: preserve calc when extra parentheses are used

### DIFF
--- a/src/lib/stringifier.js
+++ b/src/lib/stringifier.js
@@ -73,7 +73,8 @@ module.exports = function (calc, node, originalValue, options, result, item) {
   let str = stringify(node, options.precision);
 
   const shouldPrintCalc =
-    node.type === 'MathExpression' || node.type === 'Function';
+    node.type === 'MathExpression' || node.type === 'Function' ||
+    node.type === 'ParenthesizedExpression';
 
   if (shouldPrintCalc) {
     // if calc expression couldn't be resolved to a single value, re-wrap it as

--- a/src/lib/stringifier.js
+++ b/src/lib/stringifier.js
@@ -79,7 +79,11 @@ module.exports = function (calc, node, originalValue, options, result, item) {
   if (shouldPrintCalc) {
     // if calc expression couldn't be resolved to a single value, re-wrap it as
     // a calc()
-    str = `${calc}(${str})`;
+    if (node.type === 'ParenthesizedExpression') {
+      str = `${calc}${str}`;
+    } else {
+      str = `${calc}(${str})`;
+    }
 
     // if the warnWhenCannotResolve option is on, inform the user that the calc
     // expression could not be resolved to a single value

--- a/test/index.js
+++ b/test/index.js
@@ -772,7 +772,7 @@ test(
   'should preserve calc when extra parentheses are used',
   testValue(
     'calc((var(--circumference) / var(--number-of-segments)))',
-    'calc((var(--circumference)/var(--number-of-segments)))'
+    'calc(var(--circumference)/var(--number-of-segments))'
   )
 );
 

--- a/test/index.js
+++ b/test/index.js
@@ -768,6 +768,14 @@ test(
   )
 );
 
+test(
+  'should preserve calc when extra parentheses are used',
+  testValue(
+    'calc((var(--circumference) / var(--number-of-segments)))',
+    'calc((var(--circumference)/var(--number-of-segments)))'
+  )
+);
+
 test('precision for calc', testValue('calc(100% / 3 * 3)', '100%'));
 
 test(


### PR DESCRIPTION
Fixes #181

This fix allows `calc` to be printed when `calc((...))` is encountered. The bug occurred because the AST was `'type: 'ParenthesizedExpression'` which didn't satisfy the [`shouldPrintCalc`](https://github.com/postcss/postcss-calc/blob/master/src/lib/stringifier.js#L75) check in `stringifier.js`. The test I added piggy backs on the work started in #180. All the original tests pass with this addition, but I am new to the codebase so I very well could be missing some things.

https://github.com/cssnano/cssnano/issues/1490#issuecomment-1534215112

TODOs:
- remove the extra parentheses e.g. `calc((var(--foo) / var(--bar))` should become `calc(var(--foo) / var(--bar)`
- preserve the space between the division operator e.g. `calc((var(--foo) / var(--bar))` should preserve the space if that is intended/expected behavior.